### PR TITLE
Fix extra comma in cut clause

### DIFF
--- a/DSLTransEngine/src/dsltrans/transformer/filter/MatchFilter.java
+++ b/DSLTransEngine/src/dsltrans/transformer/filter/MatchFilter.java
@@ -727,7 +727,11 @@ public class MatchFilter {
 		
 		String cutclause = getCutClause();
 		if(!cutclause.isEmpty()){
-			queryBody += "," + cutclause;
+			if(!first){
++				queryBody += ",";
++			}
++			queryBody += cutclause;
+			first = false;
 		}	
 
 		generateDifferentEntitiesFactCall(positiveMatchAndApplyEntitiesIDList);


### PR DESCRIPTION
Fixes an error with an extra comma in the cut clause. Seen while running Families to Person transformation in MPS version.